### PR TITLE
Updated README to add support for Gradle 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ folder in your app project and add the reference to its `build.gradle` file.
 For version `24-noconnect-2.20b` it would be:
 
 ```
-compile 'com.spotify.sdk:spotify-player-24-noconnect-2.20b@aar'
+implementation 'com.spotify.sdk:spotify-player-24-noconnect-2.20b@aar'
 ```
 
 To learn more about working with the player see the


### PR DESCRIPTION
Replaced 'compile' with 'implementation' to support changes from Gradle 3.0 as 'compile' is deprecated