### PR TITLE
Add Maven central repository

### DIFF
--- a/samples/DemoProject/build.gradle
+++ b/samples/DemoProject/build.gradle
@@ -1,4 +1,7 @@
 buildscript {
+    repositories {
+        mavenCentral()
+    }
     dependencies {
         classpath "com.android.tools.build:gradle:2.1.3"
     }


### PR DESCRIPTION
Hello,

I'm getting this error when I try to build the demo:
```
A problem occurred configuring root project 'DemoProject'.
> Could not resolve all dependencies for configuration ':classpath'.
   > Cannot resolve external dependency com.android.tools.build:gradle:2.1.3 because no repositories are defined.
     Required by:
         :DemoProject:unspecified
```

This patch fixes it.