### PR TITLE
Fix issue #22 - Missing Jackson dependency in demo app

### DIFF
--- a/app-remote-sample/build.gradle
+++ b/app-remote-sample/build.gradle
@@ -78,4 +78,9 @@ dependencies {
     implementation "com.android.support:appcompat-v7:$supportLibVersion"
     implementation "com.android.support:gridlayout-v7:$supportLibVersion"
     implementation "com.google.code.gson:gson:2.8.5"
+
+    // Jackson Dependencies
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.7.3'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.7.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.7.3'
 }


### PR DESCRIPTION
Building the demo app produces the following error message: `Failed to find byte code for com/fasterxml/jackson/databind/deser/std/StdDeserializer) present in current demo app implementation.`

Related to issue #22. 